### PR TITLE
Fixed git checkout

### DIFF
--- a/dick-web/src/main/java/com/dickthedeployer/dick/web/service/RepositoryService.java
+++ b/dick-web/src/main/java/com/dickthedeployer/dick/web/service/RepositoryService.java
@@ -127,9 +127,7 @@ public class RepositoryService {
     }
 
     private void initializeRepository(Path path, Repo repository) {
-        commandService.invoke(path, "git", "init");
-        commandService.invoke(path, "git", "clone", repository.getRepository());
-        commandService.invoke(path, "git", "remote", "add", "origin", repository.getRepository());
+        commandService.invoke(path, "git", "clone", repository.getRepository(), ".");
     }
 
     private void checkoutRevision(Path path, String ref, String sha) {


### PR DESCRIPTION
Fixed git checkout -- the code was checking out the code twice (once directly in build folder and once in a subdirectory named same as the repository).
