### PR TITLE
Temporary fix for 404 on page refresh issue

### DIFF
--- a/dick-web/src/main/java/com/dickthedeployer/dick/web/Application.java
+++ b/dick-web/src/main/java/com/dickthedeployer/dick/web/Application.java
@@ -21,15 +21,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
- *
  * @author mariusz
  */
 @EnableAsync
-@Controller
 @EnableScheduling
 @SpringBootApplication
 public class Application {
@@ -37,11 +33,6 @@ public class Application {
     @Bean
     public RandomNameGenerator randomNameGenerator() {
         return new RandomNameGenerator();
-    }
-
-    @RequestMapping(value = "/{path:[^\\.]*}")
-    public String redirect() {
-        return "forward:/";
     }
 
     public static void main(String[] args) {

--- a/dick-web/src/main/java/com/dickthedeployer/dick/web/WebMvcConfig.java
+++ b/dick-web/src/main/java/com/dickthedeployer/dick/web/WebMvcConfig.java
@@ -1,0 +1,35 @@
+package com.dickthedeployer.dick.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.ResourceProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.resource.PathResourceResolver;
+
+import java.io.IOException;
+
+@Configuration
+@EnableConfigurationProperties(ResourceProperties.class)
+public class WebMvcConfig extends WebMvcConfigurerAdapter {
+
+    @Autowired
+    private ResourceProperties resourceProperties;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/**")
+                .addResourceLocations("classpath:/META-INF/resources/")
+                .setCachePeriod(resourceProperties.getCachePeriod()).resourceChain(true)
+                .addResolver(new PathResourceResolver() {
+                    @Override
+                    protected Resource getResource(String resourcePath, Resource location) throws IOException {
+                        Resource resourceLocation = location.createRelative(resourcePath);
+                        return location.createRelative(resourceLocation.exists() && resourceLocation.isReadable()
+                                ? resourcePath : "/index.html");
+                    }
+                });
+    }
+}


### PR DESCRIPTION
Temporary fix for 404 on page refresh issue. Everything that would end up with 404 will get index.html contents instead. In the future we should either reconsider url scheme we use or implement router-like logic on server-side to serve index.html or respond with 404 depending on url validity.
